### PR TITLE
Added environment_macos.yml for MacOS Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Here are the example install commands for the supported models:
 ## Using Conda
 The version of PyMOL that can be downloaded from the [Schrödinger website](https://pymol.org/) is currently compiled with Python 3.10. On some operating systems, you may have some difficulties installing the various model packages with this Python version.
 
-To get around this, we can use [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) to get PyMOL with a different version of Python that will *hopefully* work with your desired folding library. You can modify the provided [envs/environment.yml](envs/environment.yml) file to install the desired Python version + model package. (Note: You likely cannot install all of the model libraries at the same time as they have dependency conflicts.)
+To get around this, we can use [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) to get PyMOL with a different version of Python that will *hopefully* work with your desired folding library. You can modify the provided [envs/environment.yml](envs/environment.yml) file to install the desired Python version + model package. (Note: You likely cannot install all of the model libraries at the same time as they have dependency conflicts.) We have also provided some example eviroment files for the different models in the `envs/` directory.
 
 ```bash
+## Change the `environment.yml` file to the corresponding YAML file of the model you want to use.
 conda env create --file envs/environment.yml
 ## Go get a ☕️ as this will take a while.
 
@@ -76,7 +77,7 @@ pymol ## This will open the GUI
 ```
 
 > [!NOTE]
-> Note: MacOS environment will depend on the pymol-open-source package. If MacOS users are installing through conda, they should use the envs/environment_macos.yml file instead.  
+> Note: Some macOS users may need to use the `pymol-open-source` package. If you prefer/need to use the open-source version of PyMOL and wish to install through conda, modify the `envs/opensource_environment.yml` environment file. 
 
 ## Feature Roadmap
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ pymol ## This will open the GUI
 # conda remove -n pymolfold --all
 ```
 
+> [!NOTE]
+> Note: MacOS environment will depend on the pymol-open-source package. If MacOS users are installing through conda, they should use the envs/environment_macos.yml file instead.  
+
 ## Feature Roadmap
 
 - [ ] Support for multiple protein chains (with `esm3-medium-multimer-2024-09`).

--- a/envs/environment_macos.yml
+++ b/envs/environment_macos.yml
@@ -1,0 +1,18 @@
+# run: conda env create --file environment_macos.yml
+name: pymolfold
+channels:
+  - conda-forge
+dependencies:
+- python>=3.12
+- pip
+- pymol-open-source
+- pyqt
+## Uncomment the pip and the model you'd like to install and use
+## Models can also be individually installed using pip install
+## Note: It's unlikely that you can install all models at once due to conflicting dependencies
+# - pip:
+  # - esm
+  # - boltz
+  # - chai_lab
+  # - git+https://github.com/chaidiscovery/chai-lab.git
+  # - protenix

--- a/envs/opensource_environment.yml
+++ b/envs/opensource_environment.yml
@@ -1,5 +1,4 @@
-# run: conda env create --file environment_macos.yml
-name: pymolfold
+name: pymolfold_opensource
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
I tested the code on a Windows machine and did not run into any issues installing PyMOLfold. 

However, on my personal machine - MacOS - I have issues during installation with this error:

```
ResolvePackageNotFound: 
  - pymol-bundle
```

I fixed this by removing the Schrödinger channel and replacing **pymol-bundle** with **pymol-open-source** in the environment.yml file. 

To better fit what is seen in PyMOLfold envs folder, I have included a new .yml file for macOS with these changes entitled **environment_macos.yml**. 

I have also added a note to the README.md file under conda section regarding conda installation on MacOS. 